### PR TITLE
align compression func with doc description

### DIFF
--- a/ethsnarks/jubjub.py
+++ b/ethsnarks/jubjub.py
@@ -235,7 +235,7 @@ class Point(AbstractCurveOps, namedtuple('_Point', ('x', 'y'))):
 		return hash((self.x, self.y))
 
 	def compress(self):
-		x = self.x.n
+		x = self.x
 		y = self.y.n
 		return int.to_bytes(y | (is_negative(x) << 255), 32, "little")
 

--- a/ethsnarks/jubjub.py
+++ b/ethsnarks/jubjub.py
@@ -68,7 +68,7 @@ assert JUBJUB_D == (MONT_A-2)/MONT_B
 
 def is_negative(v):
 	assert isinstance(v, FQ)
-	return v.n < (-v).n
+	return v.n > (-v).n
 
 
 class AbstractCurveOps(object):
@@ -160,7 +160,7 @@ class Point(AbstractCurveOps, namedtuple('_Point', ('x', 'y'))):
 		x = xsq.sqrt()
 		if sign is not None:
 			# Used for compress & decompress
-			if (x.n & 1) != sign:
+			if is_negative(x) ^ (sign != 0):
 				x = -x
 		else:
 			if is_negative(x):
@@ -237,7 +237,7 @@ class Point(AbstractCurveOps, namedtuple('_Point', ('x', 'y'))):
 	def compress(self):
 		x = self.x.n
 		y = self.y.n
-		return int.to_bytes(y | ((x&1) << 255), 32, "little")
+		return int.to_bytes(y | (is_negative(x) << 255), 32, "little")
 
 	@classmethod
 	def decompress(cls, point):


### PR DESCRIPTION
Make some changes according to doc description:

> specifically, x is negative if the (b − 1)-bit encoding of x is lexicographically larger than the (b − 1)-bit encoding of −x.

and 

> This encoding is also used to define a b-bit encoding of each element (x, y) ∈ E as a b-bit string (x, y), namely the (b − 1)-bit encoding of y followed by a sign bit; the sign bit is 1 if and only if x is negative.

